### PR TITLE
Renaming API_Version and project Parameter.

### DIFF
--- a/sample.rb
+++ b/sample.rb
@@ -3,7 +3,7 @@ require 'highline/import'
 require './oauth_util'
 
 # Constants for use as request parameters.
-API_VERSION = 'v1beta2'
+API_VERSION = 'v1'
 DEFAULT_PROJECT = 'YOUR_PROJECT_ID'
 DEFAULT_BUCKET = 'YOUR_DEFAULT_BUCKET'
 DEFAULT_OBJECT = 'YOUR_DEFAULT_OBJECT'
@@ -33,7 +33,7 @@ api_request_selection_map = {
 # Linking each API request to appropriate request parameters.
 api_request_parameter_map = {
   storage.buckets.list => {
-    'projectId' => DEFAULT_PROJECT
+    'project' => DEFAULT_PROJECT
   },
   storage.objects.list => {
     'bucket' => DEFAULT_BUCKET


### PR DESCRIPTION
* Google doesn't support v1beta1/2 anymore.
* 'projectId' parameter is no longer supported, new parameter is 'project'

{
 "error": {
  "errors": [
   {
    "domain": "global",
    "reason": "turnedDown",
    "message": "Version v1beta2 of this API is no longer available. Please try again using JSON API v1. To request temporary reinstatement for your project, please visit https://docs.google.com/forms/d/1isIxBZg3rsQbDN_TOalZaz1WT_ebJchsrlv-Qr_r9mY/viewform?entry.244568692=38914250655&entry.176324201=v1beta2&entry.1071661541-Qr_r9mY/prefill",
    "extendedHelp": "https://cloud.google.com/storage/docs/json_api/v1/how-tos/migrate"
   }
  ],
  "code": 400,
  "message": "Version v1beta2 of this API is no longer available. Please try again using JSON API v1. To request temporary reinstatement for your project, please visit https://docs.google.com/forms/d/1isIxBZg3rsQbDN_TOalZaz1WT_ebJchsrlv-Qr_r9mY/viewform?entry.244568692=38914250655&entry.176324201=v1beta2&entry.1071661541-Qr_r9mY/prefill"
 }
}

ArgumentError: Missing required parameters: project.
from /Users/adihochmann/work/lab/ruby/2.1.0/gems/google-api-client-0.8.2/lib/google/api_client/discovery/method.rb:311:in `validate_parameters'